### PR TITLE
Enable "email to" workflow

### DIFF
--- a/app/Http/Controllers/Agent/helpdesk/MailController.php
+++ b/app/Http/Controllers/Agent/helpdesk/MailController.php
@@ -190,6 +190,7 @@ class MailController extends Controller
         if (!$body) {
             $body = $message->getMessageBody();
         }
+        $toaddress = $message->getAddresses('to');
         $subject = $message->getSubject();
         $address = $message->getAddresses('reply-to');
         if (!$address) {
@@ -198,10 +199,10 @@ class MailController extends Controller
         $collaborators = $this->collaburators($message, $email);
         $attachments = $message->getAttachments();
         //dd(['body' => $body, 'subject' => $subject, 'address' => $address, 'cc' => $collaborator, 'attachments' => $attachments]);
-        $this->workflow($address, $subject, $body, $collaborators, $attachments, $email);
+        $this->workflow($address, $subject, $toaddress, $body, $collaborators, $attachments, $email);
     }
 
-    public function workflow($address, $subject, $body, $collaborator, $attachments, $email)
+    public function workflow($address, $subject, $toaddress, $body, $collaborator, $attachments, $email)
     {
         $fromaddress = checkArray('address', $address[0]);
         $fromname = checkArray('name', $address[0]);
@@ -217,7 +218,7 @@ class MailController extends Controller
         $team_assign = null;
         $ticket_status = null;
         $auto_response = $email->auto_response;
-        $result = $this->TicketWorkflowController->workflow($fromaddress, $fromname, $subject, $body, $phone = '', $phonecode = '', $mobile_number = '', $helptopic, $sla, $priority, $source, $collaborator, $dept, $assign, $team_assign, $ticket_status, $form_data = [], $auto_response);
+        $result = $this->TicketWorkflowController->workflow($fromaddress, $fromname, $toaddress, $subject, $body, $phone = '', $phonecode = '', $mobile_number = '', $helptopic, $sla, $priority, $source, $collaborator, $dept, $assign, $team_assign, $ticket_status, $form_data = [], $auto_response);
         if ($result[1] == true) {
             $this->updateThread($result[0], $body, $attachments);
         }

--- a/app/Http/Controllers/Agent/helpdesk/TicketWorkflowController.php
+++ b/app/Http/Controllers/Agent/helpdesk/TicketWorkflowController.php
@@ -61,6 +61,10 @@ class TicketWorkflowController extends Controller
                         if ($rule_condition = $this->checkRuleCondition($contact_details['email_name'], $worklfow_rule->matching_relation, $worklfow_rule->matching_value) == true) {
                             $ticket_settings_details = $this->applyActionCondition($workflow->id, $ticket_settings_details);
                         }
+                    } elseif ($worklfow_rule->matching_scenario == 'email_to') {
+                        if ($rule_condition = $this->checkRuleCondition($contact_details['email_to'], $worklfow_rule->matching_relation, $worklfow_rule->matching_value) == true) {
+                            $ticket_settings_details = $this->applyActionCondition($workflow->id, $ticket_settings_details);
+                        }
                     } elseif ($worklfow_rule->matching_scenario == 'subject') {
                         if ($rule_condition = $this->checkRuleCondition($contact_details['subject'], $worklfow_rule->matching_relation, $worklfow_rule->matching_value) == true) {
                             $ticket_settings_details = $this->applyActionCondition($workflow->id, $ticket_settings_details);

--- a/app/Http/Controllers/Agent/helpdesk/TicketWorkflowController.php
+++ b/app/Http/Controllers/Agent/helpdesk/TicketWorkflowController.php
@@ -128,11 +128,10 @@ class TicketWorkflowController extends Controller
                             } elseif ($worklfow_rule->matching_scenario == 'email_name') {
                                 if ($rule_condition = $this->checkRuleCondition($contact_details['email_name'], $worklfow_rule->matching_relation, $worklfow_rule->matching_value) == true) {
                                     $ticket_settings_details = $this->applyActionCondition($workflows_email->id, $ticket_settings_details);
-                                } elseif ($worklfow_rule->matching_scenario == 'email_to') {
-                                
+                                }
+                            } elseif ($worklfow_rule->matching_scenario == 'email_to') {
                                 foreach ($contact_details['email_to'] as $email_toaddress => $email_toname) {
                                     if ($rule_condition = $this->checkRuleCondition($email_toaddress, $worklfow_rule->matching_relation, $worklfow_rule->matching_value) == true) {
-                            \Log::info('applying condition');
                                         $ticket_settings_details = $this->applyActionCondition($workflows_email->id, $ticket_settings_details);
                                         break;
                                     }

--- a/app/Http/Controllers/Agent/helpdesk/TicketWorkflowController.php
+++ b/app/Http/Controllers/Agent/helpdesk/TicketWorkflowController.php
@@ -40,9 +40,9 @@ class TicketWorkflowController extends Controller
      *
      * @return type response
      */
-    public function workflow($fromaddress, $fromname, $subject, $body, $phone, $phonecode, $mobile_number, $helptopic, $sla, $priority, $source, $collaborator, $dept, $assign, $team_assign, $ticket_status, $form_data, $auto_response)
+    public function workflow($fromaddress, $fromname, $toaddress, $subject, $body, $phone, $phonecode, $mobile_number, $helptopic, $sla, $priority, $source, $collaborator, $dept, $assign, $team_assign, $ticket_status, $form_data, $auto_response)
     {
-        $contact_details = ['email' => $fromaddress, 'email_name' => $fromname, 'subject' => $subject, 'message' => $body];
+        $contact_details = ['email' => $fromaddress, 'email_name' => $fromname, 'email_to' => $toaddress, 'subject' => $subject, 'message' => $body];
         $ticket_settings_details = ['help_topic' => $helptopic, 'sla' => $sla, 'priority' => $priority, 'source' => $source, 'dept' => $dept, 'assign' => $assign, 'team' => $team_assign, 'status' => $ticket_status, 'reject' => false];
         // get all the workflow common to the entire system which includes any type of ticket creation where the execution order of the workflow should be starting with ascending order
         $workflows = WorkflowName::where('target', '=', 'A-0')->where('status', '=', '1')->orderBy('order', 'asc')->get();
@@ -94,6 +94,10 @@ class TicketWorkflowController extends Controller
                                 if ($this->checkRuleCondition($contact_details['email_name'], $worklfow_rule->matching_relation, $worklfow_rule->matching_value) == true) {
                                     $ticket_settings_details = $this->applyActionCondition($workflows_web->id, $ticket_settings_details);
                                 }
+                            } elseif ($worklfow_rule->matching_scenario == 'email_to') {
+                                if ($this->checkRuleCondition($contact_details['email_to'], $worklfow_rule->matching_relation, $worklfow_rule->matching_value) == true) {
+                                    $ticket_settings_details = $this->applyActionCondition($workflows_web->id, $ticket_settings_details);
+                                }
                             } elseif ($worklfow_rule->matching_scenario == 'subject') {
                                 if ($this->checkRuleCondition($contact_details['subject'], $worklfow_rule->matching_relation, $worklfow_rule->matching_value) == true) {
                                     $ticket_settings_details = $this->applyActionCondition($workflows_web->id, $ticket_settings_details);
@@ -124,6 +128,14 @@ class TicketWorkflowController extends Controller
                             } elseif ($worklfow_rule->matching_scenario == 'email_name') {
                                 if ($rule_condition = $this->checkRuleCondition($contact_details['email_name'], $worklfow_rule->matching_relation, $worklfow_rule->matching_value) == true) {
                                     $ticket_settings_details = $this->applyActionCondition($workflows_email->id, $ticket_settings_details);
+                                } elseif ($worklfow_rule->matching_scenario == 'email_to') {
+                                
+                                foreach ($contact_details['email_to'] as $email_toaddress => $email_toname) {
+                                    if ($rule_condition = $this->checkRuleCondition($email_toaddress, $worklfow_rule->matching_relation, $worklfow_rule->matching_value) == true) {
+                            \Log::info('applying condition');
+                                        $ticket_settings_details = $this->applyActionCondition($workflows_email->id, $ticket_settings_details);
+                                        break;
+                                    }
                                 }
                             } elseif ($worklfow_rule->matching_scenario == 'subject') {
                                 if ($rule_condition = $this->checkRuleCondition($contact_details['subject'], $worklfow_rule->matching_relation, $worklfow_rule->matching_value) == true) {

--- a/app/Http/Controllers/Client/helpdesk/ClientTicketController.php
+++ b/app/Http/Controllers/Client/helpdesk/ClientTicketController.php
@@ -60,6 +60,7 @@ class ClientTicketController extends Controller
     {
         $tickets = Tickets::where('id', '=', $id)->first();
         $thread = Ticket_Thread::where('ticket_id', '=', $tickets->id)->first();
+        $toaddress = '';
 
         $subject = $thread->title.'[#'.$tickets->ticket_number.']';
         $body = $request->input('comment');
@@ -84,7 +85,7 @@ class ClientTicketController extends Controller
         $ticket_status = null;
         $auto_response = 0;
 
-        $this->TicketWorkflowController->workflow($fromaddress, $fromname, $subject, $body, $phone, $phonecode, $mobile_number, $helptopic, $sla, $priority, $source, $collaborator, $dept, $assign, $team_assign, $ticket_status, $form_data, $auto_response);
+        $this->TicketWorkflowController->workflow($fromaddress, $fromname, $toaddress, $subject, $body, $phone, $phonecode, $mobile_number, $helptopic, $sla, $priority, $source, $collaborator, $dept, $assign, $team_assign, $ticket_status, $form_data, $auto_response);
 
         return \Redirect::back()->with('success1', Lang::get('lang.successfully_replied'));
     }

--- a/app/Http/Controllers/Client/helpdesk/FormController.php
+++ b/app/Http/Controllers/Client/helpdesk/FormController.php
@@ -148,6 +148,7 @@ class FormController extends Controller
     {
         $form_extras = $request->except('Name', 'Phone', 'Email', 'Subject', 'Details', 'helptopic', '_wysihtml5_mode', '_token', 'mobile', 'Code');
         $name = $request->input('Name');
+        $toaddress = '';
         $phone = $request->input('Phone');
         if ($request->input('Email')) {
             if ($request->input('Email')) {
@@ -215,7 +216,7 @@ class FormController extends Controller
                 }
             }
         }
-        $result = $this->TicketWorkflowController->workflow($email, $name, $subject, $details, $phone, $phonecode, $mobile_number, $helptopic, $sla, $priority, $source, $collaborator, $department, $assignto, $team_assign, $status, $form_extras, $auto_response);
+        $result = $this->TicketWorkflowController->workflow($email, $name, $toaddress, $subject, $details, $phone, $phonecode, $mobile_number, $helptopic, $sla, $priority, $source, $collaborator, $department, $assignto, $team_assign, $status, $form_extras, $auto_response);
         // dd($result);
         if ($result[1] == 1) {
             $ticketId = Tickets::where('ticket_number', '=', $result[0])->first();
@@ -261,6 +262,7 @@ class FormController extends Controller
 
                 $fromaddress = $user_cred->email;
                 $fromname = $user_cred->user_name;
+                $toaddress = '';
                 $phone = '';
                 $phonecode = '';
                 $mobile_number = '';
@@ -277,7 +279,7 @@ class FormController extends Controller
                 $ticket_status = null;
                 $auto_response = 0;
 
-                $this->TicketWorkflowController->workflow($fromaddress, $fromname, $subject, $body, $phone, $phonecode, $mobile_number, $helptopic, $sla, $priority, $source, $collaborator, $dept, $assign, $team_assign, $ticket_status, $form_data, $auto_response);
+                $this->TicketWorkflowController->workflow($fromaddress, $fromname, $toaddress, $subject, $body, $phone, $phonecode, $mobile_number, $helptopic, $sla, $priority, $source, $collaborator, $dept, $assign, $team_assign, $ticket_status, $form_data, $auto_response);
 
                 return \Redirect::back()->with('success1', Lang::get('lang.successfully_replied'));
             } else {

--- a/resources/lang/en/lang.php
+++ b/resources/lang/en/lang.php
@@ -131,6 +131,8 @@ return [
     'create_email'                                                                     => 'Create email',
     'email_address'                                                                    => 'Email address',
     'email_name'                                                                       => 'Email name',
+    'email_from'                                                                       => 'Email from',
+    'email_to'                                                                         => 'Email to',
     'help_topic'                                                                       => 'Help topic',
     'auto_response'                                                                    => 'Auto response',
     'host_name'                                                                        => 'Host name',

--- a/resources/views/themes/default1/admin/helpdesk/manage/workflow/create.blade.php
+++ b/resources/views/themes/default1/admin/helpdesk/manage/workflow/create.blade.php
@@ -134,8 +134,9 @@ class="active"
                                                 <td>
                                                     <select class="form-control" name="rule[0][a]" required>
                                                         <option value="">-- {!! Lang::get('lang.select_one') !!} --</option>
-                                                        <option value="email">{!! Lang::get('lang.email') !!}</option>
+                                                        <option value="email">{!! Lang::get('lang.email_from') !!}</option>
                                                         <option value="email_name">{!! Lang::get('lang.email_name') !!}</option>
+                                                        <option value="email_to">{!! Lang::get('lang.email_to') !!}</option>
                                                         <option value="subject">{!! Lang::get('lang.subject') !!}</option>
                                                         <option value="message">{!! Lang::get('lang.message') !!}/{!! Lang::get('lang.body') !!}</option>
                                                     </select>

--- a/resources/views/themes/default1/admin/helpdesk/manage/workflow/edit.blade.php
+++ b/resources/views/themes/default1/admin/helpdesk/manage/workflow/edit.blade.php
@@ -173,12 +173,17 @@ class="active"
                                                         if ($workflow_rule->matching_scenario == 'email') {
                                                             echo "selected='selected'";
                                                         }
-                                                        ?> >{!! Lang::get('lang.email') !!}</option>
+                                                        ?> >{!! Lang::get('lang.email_from') !!}</option>
                                                         <option value="email_name" <?php
                                                         if ($workflow_rule->matching_scenario == 'email_name') {
                                                             echo "selected='selected'";
                                                         }
                                                         ?> >{!! Lang::get('lang.email_name') !!}</option>
+                                                        <option value="email_to" <?php
+                                                        if ($workflow_rule->matching_scenario == 'email_to') {
+                                                            echo "selected='selected'";
+                                                        }
+                                                        ?> >{!! Lang::get('lang.email_to') !!}</option>
                                                         <option value="subject" <?php
                                                         if ($workflow_rule->matching_scenario == 'subject') {
                                                             echo "selected='selected'";


### PR DESCRIPTION
Allows setting a workflow depending on the email address the support email was sent to (eg, multiple aliases ending up in the one inbox).

(Previously added, but lost in the last release)