### PR TITLE
Fix for value when not converted to int automatically

### DIFF
--- a/resources/views/themes/default1/installer/helpdesk/view2.blade.php
+++ b/resources/views/themes/default1/installer/helpdesk/view2.blade.php
@@ -74,6 +74,7 @@ function validate_php(&$results) {
 function php_config_value_to_bytes($val) {
     $val = trim($val);
     $last = strtolower($val{strlen($val) - 1});
+    $val = (int)$val;
     switch ($last) {
         // The 'G' modifier is available since PHP 5.1.0
         case 'g':


### PR DESCRIPTION
On PHP 7.1 it shows error when the value is not explicit converted to int