### PR TITLE
Removed Artisan optimize command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -62,12 +62,10 @@
     },
     "scripts": {
         "post-install-cmd": [
-            "php artisan clear-compiled",
-            "php artisan optimize"
+            "php artisan clear-compiled"
         ],
         "post-update-cmd": [
-            "php artisan clear-compiled",
-            "php artisan optimize"
+            "php artisan clear-compiled"
         ],
         "post-create-project-cmd": [
             "php -r \"copy('.env.example', '.env');\"",


### PR DESCRIPTION
As mentioned in upgrade guide for laravel version 5.6 Optimize command has been removed completely and any reference to this must be removed from the project including `composer.json` file.

References:
https://laravel-news.com/laravel-5-6-removes-artisan-optimize
https://tutsforweb.com/laravel-5-6-removed-artisan-optimize/