### PR TITLE
Fix plugin activation error for  server installed in windows

### DIFF
--- a/app/Http/Controllers/Common/SettingsController.php
+++ b/app/Http/Controllers/Common/SettingsController.php
@@ -585,7 +585,14 @@ class SettingsController extends Controller
         $plug = $plugs->where('name', $slug)->first();
         if (!$plug) {
             $app = base_path().DIRECTORY_SEPARATOR.'config'.DIRECTORY_SEPARATOR.'app.php';
-            $str = "\n'App\\Plugins\\$slug"."\\ServiceProvider',";
+            
+            /*verify if the server is installed on windows or linux */
+            if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') { 
+                $str = "\r'App\\Plugins\\$slug"."\\ServiceProvider',";
+            } else {
+                $str = "\n'App\\Plugins\\$slug"."\\ServiceProvider',";
+            }
+
             $line_i_am_looking_for = 190;
             $lines = file($app, FILE_IGNORE_NEW_LINES);
             $lines[$line_i_am_looking_for] = $str;

--- a/app/Http/Controllers/Common/SettingsController.php
+++ b/app/Http/Controllers/Common/SettingsController.php
@@ -585,14 +585,12 @@ class SettingsController extends Controller
         $plug = $plugs->where('name', $slug)->first();
         if (!$plug) {
             $app = base_path().DIRECTORY_SEPARATOR.'config'.DIRECTORY_SEPARATOR.'app.php';
-            
             /*verify if the server is installed on windows or linux */
             if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') { 
                 $str = "\r'App\\Plugins\\$slug"."\\ServiceProvider',";
             } else {
                 $str = "\n'App\\Plugins\\$slug"."\\ServiceProvider',";
             }
-
             $line_i_am_looking_for = 190;
             $lines = file($app, FILE_IGNORE_NEW_LINES);
             $lines[$line_i_am_looking_for] = $str;
@@ -606,7 +604,11 @@ class SettingsController extends Controller
             $plug->status = 1;
 
             $app = base_path().DIRECTORY_SEPARATOR.'config'.DIRECTORY_SEPARATOR.'app.php';
-            $str = "\n'App\\Plugins\\$slug"."\\ServiceProvider',";
+            if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') { 
+                $str = "\r'App\\Plugins\\$slug"."\\ServiceProvider',";
+            }else {
+                $str = "\n'App\\Plugins\\$slug"."\\ServiceProvider',";
+            }
             $line_i_am_looking_for = 190;
             $lines = file($app, FILE_IGNORE_NEW_LINES);
             $lines[$line_i_am_looking_for] = $str;


### PR DESCRIPTION
Fix app crash when activating a plugin in server installed on windows (wamp, xamp , ampps) because of the new line \n is working as expected on linux only.