### PR TITLE
v1.10.6 updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_script:
 - composer self-update
 - composer install --prefer-source --no-interaction --dev
 - php artisan testing-setup --username="root"
-script: phpunit
+script: vendor/bin/phpunit
 matrix:
   allow_failures:
   - php: 5.5

--- a/DB/demodatabase.sql
+++ b/DB/demodatabase.sql
@@ -1457,7 +1457,7 @@ CREATE TABLE `settings_system` (
 --
 
 INSERT INTO `settings_system` (`id`, `status`, `url`, `name`, `department`, `page_size`, `log_level`, `purge_log`, `api_enable`, `api_key_mandatory`, `api_key`, `name_format`, `time_farmat`, `date_format`, `date_time_format`, `day_date_time`, `time_zone`, `content`, `version`, `created_at`, `updated_at`) VALUES
-(1, 1, '', '', '1', '', '', '', 0, 0, '', '', NULL, NULL, 1, '', 32, '', '1.10.5', '2016-12-13 03:19:29', '2016-12-13 03:19:29');
+(1, 1, '', '', '1', '', '', '', 0, 0, '', '', NULL, NULL, 1, '', 32, '', '1.10.6', '2016-12-13 03:19:29', '2016-12-13 03:19:29');
 
 -- --------------------------------------------------------
 

--- a/DB/dummy-data.sql
+++ b/DB/dummy-data.sql
@@ -1,4 +1,4 @@
--- phpMyAdmin SQL Dump
+Community v1.10.6 04/19/2019-- phpMyAdmin SQL Dump
 -- version 4.6.6deb5
 -- https://www.phpmyadmin.net/
 --
@@ -1457,7 +1457,7 @@ CREATE TABLE `settings_system` (
 --
 
 INSERT INTO `settings_system` (`id`, `status`, `url`, `name`, `department`, `page_size`, `log_level`, `purge_log`, `api_enable`, `api_key_mandatory`, `api_key`, `name_format`, `time_farmat`, `date_format`, `date_time_format`, `day_date_time`, `time_zone`, `content`, `version`, `created_at`, `updated_at`) VALUES
-(1, 1, '', '', '1', '', '', '', 0, 0, '', '', NULL, NULL, 1, '', 32, '', '1.10.5', '2016-12-13 03:19:29', '2016-12-13 03:19:29');
+(1, 1, '', '', '1', '', '', '', 0, 0, '', '', NULL, NULL, 1, '', 32, '', '1.10.6', '2016-12-13 03:19:29', '2016-12-13 03:19:29');
 
 -- --------------------------------------------------------
 

--- a/config/app.php
+++ b/config/app.php
@@ -33,7 +33,7 @@ return [
       | This tells about aplication current version.
       |
      */
-    'version' => 'Community 1.10.5',
+    'version' => 'Community 1.10.6',
     /*
       |--------------------------------------------------------------------------
       | Application Name

--- a/release-notes.txt
+++ b/release-notes.txt
@@ -8,9 +8,22 @@
                                           | |                         
                                           |_|                         
 |=====================================================
+| v1.10.6 Chrome UI issue fix patch
+|=====================================================
+Issue #1665 fix patch
+
+Recent updates of Chrome browser introduced an issue in ticket timeline page where the reply threads from users were not visible in chrome browser's latest version. 
+
+The last release fixed the issue for agent/admin view. However, the issue persisted for client view in Chrome browser. Check out [the issue](https://github.com/ladybirdweb/faveo-helpdesk/issues/1665) raised for the same.
+
+Issue Reported by: [@n3zsistemas](https://github.com/n3zsistemas)
+
+We would like to thank the Faveo community users who report their issues with the system and help us to make Faveo Helpdesk better for other users.
+
+|=====================================================
 | v1.10.5 Chrome UI issue fix patch
 |=====================================================
-Recent updates of Chrome browser introduced an issue in ticket timeline page where the reply threads from users were not visible in chrome browser's latest version.
+Recent updates of Chrome browser introduced an issue in ticket timeline page where the reply threads from users were not visible in chrome browser's latest version. 
 
 |=====================================================
 | v1.10.4 Security patch for Slack channel

--- a/resources/views/themes/default1/client/helpdesk/ckeckticket.blade.php
+++ b/resources/views/themes/default1/client/helpdesk/ckeckticket.blade.php
@@ -229,7 +229,7 @@ foreach ($conversations as $conversation) {
                                             <script>
                                             setTimeout(function(){
                                                 var $iframe="Id{{$conversation->id}}";
-                                                $('<iframe src="javascript:void(0)" id='+$iframe+' class="iframe" frameborder="0"  scrolling="no" width="100%" style="height:1px"></iframe>').appendTo(".embed-responsive{{$conversation->id}}");
+                                                $('<iframe src="about:blank" id='+$iframe+' class="iframe" frameborder="0"  scrolling="no" width="100%" style="height:1px"></iframe>').appendTo(".embed-responsive{{$conversation->id}}");
                                                 setTimeout(function(){
                                                   $('#'+$iframe).contents().find('body').append('<body><style>body{display:inline-block;}</style>{!!$conversation->purify(true)!!}<body>');
                                                    },100)


### PR DESCRIPTION
Issue #1665 fix patch

Recent updates of Chrome browser introduced an issue in ticket timeline page where the reply threads from users were not visible in chrome browser's latest version. 

The last release fixed the issue for agent/admin view. However, the issue persisted for client view in Chrome browser. Check out [the issue](https://github.com/ladybirdweb/faveo-helpdesk/issues/1665) raised for the same.

Issue Reported by: [@n3zsistemas](https://github.com/n3zsistemas)

We would like to thank the Faveo community users who report their issues with the system and help us to make Faveo Helpdesk better for other users.