### PR TITLE
Fixing new ticket creation bug upon user replay in emails with Farsi or Arabic subject

### DIFF
--- a/app/Http/Controllers/Agent/helpdesk/TicketController.php
+++ b/app/Http/Controllers/Agent/helpdesk/TicketController.php
@@ -898,7 +898,7 @@ class TicketController extends Controller
      */
     public function check_ticket($user_id, $subject, $body, $helptopic, $sla, $priority, $source, $headers, $dept, $assignto, $form_data, $status)
     {
-        $read_ticket_number = explode('[#', $subject);
+        $read_ticket_number = explode('[#', iconv_mime_decode($subject, 0, "UTF-8"));
         if (isset($read_ticket_number[1])) {
             $separate = explode(']', $read_ticket_number[1]);
             $new_subject = substr($separate[0], 0, 20);

--- a/app/Http/Controllers/Agent/helpdesk/TicketController.php
+++ b/app/Http/Controllers/Agent/helpdesk/TicketController.php
@@ -898,7 +898,7 @@ class TicketController extends Controller
      */
     public function check_ticket($user_id, $subject, $body, $helptopic, $sla, $priority, $source, $headers, $dept, $assignto, $form_data, $status)
     {
-        $read_ticket_number = explode('[#', iconv_mime_decode($subject, 0, "UTF-8"));
+        $read_ticket_number = explode('[#', iconv_mime_decode($subject, 0, 'UTF-8'));
         if (isset($read_ticket_number[1])) {
             $separate = explode(']', $read_ticket_number[1]);
             $new_subject = substr($separate[0], 0, 20);


### PR DESCRIPTION
Everything works perfect till the user send an email and you answer it. when the user replays to your answer, if the subject is in Farsi or Arabic it will create a new ticket. this is not the intended behavior. the bug was in `TicketController` where the `check_ticket` function didn't take MIME headers for Farsi and Arabic into account. now the bug has been resolved and Faveo-HelpDesk is working perfectly.

now we can close this issue happily ever after #1963 