### PR TITLE
Add OpenID Connect provider in Social Login

### DIFF
--- a/app/Http/Controllers/Admin/helpdesk/SocialMedia/SocialMediaController.php
+++ b/app/Http/Controllers/Admin/helpdesk/SocialMedia/SocialMediaController.php
@@ -90,6 +90,7 @@ class SocialMediaController extends Controller
             \Config::set("services.$service.client_id", $social->getvalueByKey($service, 'client_id'));
             \Config::set("services.$service.client_secret", $social->getvalueByKey($service, 'client_secret'));
             \Config::set("services.$service.redirect", $social->getvalueByKey($service, 'redirect'));
+            \Config::set("services.$service.base_url", $social->getvalueByKey($service, 'base_url'));
         }
         // dd(\Config::get('services'));
     }
@@ -103,6 +104,7 @@ class SocialMediaController extends Controller
             'twitter',
             'linkedin',
             'bitbucket',
+            'openid_connect',
         ];
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -2239,6 +2239,7 @@
                 "SSO",
                 "authorization",
                 "bitbucket",
+                "openid_connect",
                 "identity",
                 "idp",
                 "oauth",

--- a/config/services.php
+++ b/config/services.php
@@ -61,5 +61,10 @@ return [
         'client_secret' => '', //'dD7HerXuELJR3uZQv93ZYuXsg5vLSzLR', //client secrete,
         'redirect'      => '', //'http://localhost/FaveoVersions/faveo-helpdesk/public/social/login/bitbucket', //redirect
     ],
-
+    'openid_connect' => [
+        'client_id'     => '',
+        'client_secret' => '',
+        'redirect'      => '',
+        'base_url'      => '', // Specify your provider URL here
+    ],
 ];

--- a/resources/lang/de/lang.php
+++ b/resources/lang/de/lang.php
@@ -1015,6 +1015,7 @@ return [
      */
     'client_id'     => 'Client id',
     'client_secret' => 'Client secret',
+    'base_url'      => 'Base URL',
     'redirect'      => 'Redirect URL',
     'details'       => 'Details',
     'social-media'  => 'Social media',

--- a/resources/lang/en/lang.php
+++ b/resources/lang/en/lang.php
@@ -1460,6 +1460,7 @@ return [
      */
     'client_id'     => 'Client id',
     'client_secret' => 'Client secret',
+    'base_url'      => 'Base URL',
     'redirect'      => 'Redirect URL',
     'details'       => 'Details',
     'social-media'  => 'Social media',

--- a/resources/lang/es/lang.php
+++ b/resources/lang/es/lang.php
@@ -1469,6 +1469,7 @@ Puede ingresar el número de días de registros de base de datos que se eliminar
      */
     'client_id'     => 'Client id',
     'client_secret' => 'Client secret',
+    'base_url'      => 'Base URL',
     'redirect'      => 'Redirect URL',
     'details'       => 'Details',
     'social-media'  => 'Social media',

--- a/resources/lang/fr/lang.php
+++ b/resources/lang/fr/lang.php
@@ -1422,6 +1422,7 @@ return [
      */
     'client_id'     => 'Client id',
     'client_secret' => 'Client secret',
+    'base_url'      => 'Base URL',
     'redirect'      => 'Redirect URL',
     'details'       => 'Details',
     'social-media'  => 'Social media',

--- a/resources/lang/it/lang.php
+++ b/resources/lang/it/lang.php
@@ -1456,6 +1456,7 @@ return [
      */
     'client_id'     => 'Client ID',
     'client_secret' => 'Client segreto',
+    'base_url'      => 'Base URL',
     'redirect'      => 'URL di reindirizzamento',
     'details'       => 'Dettagli',
     'social-media'  => 'Social media',

--- a/resources/lang/nl/lang.php
+++ b/resources/lang/nl/lang.php
@@ -1469,6 +1469,7 @@ return [
      */
     'client_id'     => 'Klant ID',
     'client_secret' => 'Klant geheim',
+    'base_url'      => 'Baseren URL',
     'redirect'      => 'Verwijs URL',
     'details'       => 'Details',
     'social-media'  => 'Social media',

--- a/resources/lang/pt-br/lang.php
+++ b/resources/lang/pt-br/lang.php
@@ -1410,6 +1410,7 @@ return [
      */
     'client_id'     => 'Id do cliente',
     'client_secret' => 'Secret do cliente',
+    'base_url'      => 'Base URL',
     'redirect'      => 'URL de redirecionamento',
     'details'       => 'Detalhes',
     'social-media'  => 'Mídia social',

--- a/resources/lang/pt/lang.php
+++ b/resources/lang/pt/lang.php
@@ -1412,6 +1412,7 @@ return [
      */
     'client_id'     => 'Client id',
     'client_secret' => 'Client secret',
+    'base_url'      => 'Base URL',
     'redirect'      => 'Redirect URL',
     'details'       => 'Details',
     'social-media'  => 'Social media',

--- a/resources/lang/ru/lang.php
+++ b/resources/lang/ru/lang.php
@@ -1458,6 +1458,7 @@ return [
      */
     'client_id'     => 'ID клиента',
     'client_secret' => 'Секрет клиента',
+    'base_url'      => 'URL база',
     'redirect'      => 'URL перенаправления',
     'details'       => 'Подробности',
     'social-media'  => 'Социальные медиа',

--- a/resources/lang/zh-hans/lang.php
+++ b/resources/lang/zh-hans/lang.php
@@ -1445,6 +1445,7 @@ return [
      */
     'client_id'                                                                        => '客户id',
     'client_secret'                                                                    => '客户密钥',
+    'base_url'                                                                         => '基本网址',
     'redirect'                                                                         => '跳转URL',
     'details'                                                                          => '详情',
     'social-media'                                                                     => '社会媒体',

--- a/resources/views/themes/default1/admin/helpdesk/settings/social-media/index.blade.php
+++ b/resources/views/themes/default1/admin/helpdesk/settings/social-media/index.blade.php
@@ -151,6 +151,19 @@ class="nav-link active"
                             <a href="{{url('social/media/bitbucket')}}" class="btn btn-primary">Settings</a>
                         </td>
                     </tr>
+                    <tr>
+                        <td>OpenID Connect</td>
+                        <td>
+                            @if($social->checkActive('openid_connect')===true)
+                            <span style="color: green">Active</span>
+                            @else 
+                            <span style="color: red">Inactive</span>
+                            @endif
+                        </td>
+                        <td>
+                            <a href="{{url('social/media/openid_connect')}}" class="btn btn-primary">Settings</a>
+                        </td>
+                    </tr>
                 </tbody>
             </table>
         </div>

--- a/resources/views/themes/default1/admin/helpdesk/settings/social-media/settings.blade.php
+++ b/resources/views/themes/default1/admin/helpdesk/settings/social-media/settings.blade.php
@@ -87,6 +87,13 @@ class="nav-link active"
                      {!! $errors->first('client_secret', '<spam class="help-block">:message</spam>') !!}
                 </div>
             </div>
+            <div class="col-md-6">
+                <div class="form-group {{ $errors->has('base_url') ? 'has-error' : '' }}">
+                    {!! Form::label('base_url',Lang::get('lang.base_url')) !!}<spam class="help-block"> *</spam>
+                    {!! Form::text('base_url',$social->getvalueByKey($provider,'base_url'),['class' => 'form-control']) !!}
+                    {!! $errors->first('base_url', '<spam class="help-block">:message</spam>') !!}
+                </div>
+            </div>
         </div> 
         <div class="row">
             <div class="col-md-6">

--- a/resources/views/themes/default1/client/helpdesk/social-sync/sync.blade.php
+++ b/resources/views/themes/default1/client/helpdesk/social-sync/sync.blade.php
@@ -30,6 +30,11 @@ $redirect = 'social-sync';
         <span class="fa fa-bitbucket"></span> Sign in with Bitbucket
     </a>
     @endif
+    @if($social->checkActive('openid_connect'))
+    <a class="btn btn-block btn-social btn-openid_connect" href="{{ route('social.login', ['openid_connect',$redirect]) }}" style="background-color: blue;color: white;">
+        <span class="fa fa-openid_connect"></span> Sign in with OpenID Connect
+    </a>
+    @endif
     @if($social->checkActive('github'))
     <a class="btn btn-block btn-social btn-github" href="{{ route('social.login', ['github',$redirect]) }}" style="background-color: black;color: white;">
         <span class="fa fa-github"></span> Sign in with Github

--- a/resources/views/themes/default1/client/layout/client.blade.php
+++ b/resources/views/themes/default1/client/layout/client.blade.php
@@ -1,3 +1,14 @@
+@if(!Auth::user())
+    <?php
+        $social = new \App\Model\helpdesk\Settings\SocialMedia();
+        if($social->checkActive('openid_connect') && !isset($_GET['disable_redirect'])) {
+            $redirectUrl = $social->getvalueByKey('openid_connect', 'redirect');
+            $redirectUrl = str_replace("/openid_connect", "/redirect/openid_connect", $redirectUrl); 
+            header("Location: " . $redirectUrl);
+            exit();    
+        }
+    ?>
+@endif
 <!DOCTYPE html>
 <html>
     <head>

--- a/resources/views/themes/default1/client/layout/logclient.blade.php
+++ b/resources/views/themes/default1/client/layout/logclient.blade.php
@@ -1,3 +1,14 @@
+@if(!Auth::user())
+    <?php
+        $social = new \App\Model\helpdesk\Settings\SocialMedia();
+        if($social->checkActive('openid_connect') && !isset($_GET['disable_redirect'])) {
+            $redirectUrl = $social->getvalueByKey('openid_connect', 'redirect');
+            $redirectUrl = str_replace("/openid_connect", "/redirect/openid_connect", $redirectUrl); 
+            header("Location: " . $redirectUrl);
+            exit();    
+        }
+    ?>
+@endif
 <!DOCTYPE html>
 <html>
     <head>

--- a/resources/views/themes/default1/client/layout/social-login.blade.php
+++ b/resources/views/themes/default1/client/layout/social-login.blade.php
@@ -1,7 +1,7 @@
 <?php
 $social = new \App\Model\helpdesk\Settings\SocialMedia();
 ?>
-@if($social->checkActive('twitter') || $social->checkActive('facebook') || $social->checkActive('google') || $social->checkActive('linkedin') || $social->checkActive('bitbucket') || $social->checkActive('github'))
+@if($social->checkActive('twitter') || $social->checkActive('facebook') || $social->checkActive('google') || $social->checkActive('linkedin') || $social->checkActive('bitbucket') || $social->checkActive('openid_connect') || $social->checkActive('github'))
 <center>{{Lang::get('lang.or')}}</center>
 @endif
 
@@ -28,6 +28,11 @@ $social = new \App\Model\helpdesk\Settings\SocialMedia();
 @if($social->checkActive('bitbucket'))
 <a class="btn btn-block btn-social btn-bitbucket" href="{{ route('social.login', ['bitbucket']) }}" style="background-color: blue;color: white;">
     <span class="fab fa-bitbucket"></span> Sign in with Bitbucket
+</a>
+@endif
+@if($social->checkActive('openid_connect'))
+<a class="btn btn-block btn-social btn-openid_connect" href="{{ route('social.login', ['openid_connect']) }}" style="background-color: blue;color: white;">
+    <span class="fab fa-openid_connect"></span> Sign in with OpenID Connect
 </a>
 @endif
 @if($social->checkActive('github'))

--- a/vendor/composer/installed.json
+++ b/vendor/composer/installed.json
@@ -2897,6 +2897,7 @@
             "SSO",
             "authorization",
             "bitbucket",
+            "openid_connect",
             "identity",
             "idp",
             "oauth",

--- a/vendor/laravel/socialite/readme.md
+++ b/vendor/laravel/socialite/readme.md
@@ -9,7 +9,7 @@
 
 ## Introduction
 
-Laravel Socialite provides an expressive, fluent interface to OAuth authentication with Facebook, Twitter, Google, LinkedIn, GitHub and Bitbucket. It handles almost all of the boilerplate social authentication code you are dreading writing.
+Laravel Socialite provides an expressive, fluent interface to OAuth authentication with Facebook, Twitter, Google, LinkedIn, GitHub, OpenID Connect and Bitbucket. It handles almost all of the boilerplate social authentication code you are dreading writing.
 
 **We are not accepting new adapters.**
 

--- a/vendor/laravel/socialite/src/AbstractUser.php
+++ b/vendor/laravel/socialite/src/AbstractUser.php
@@ -28,6 +28,20 @@ abstract class AbstractUser implements ArrayAccess, Contracts\User
     public $name;
 
     /**
+     * The user's last name.
+     *
+     * @var string
+     */
+    public $lastname;
+
+    /**
+     * The user's role.
+     *
+     * @var string
+     */
+    public $role;
+
+    /**
      * The user's e-mail address.
      *
      * @var string
@@ -76,6 +90,26 @@ abstract class AbstractUser implements ArrayAccess, Contracts\User
     public function getName()
     {
         return $this->name;
+    }
+
+    /**
+     * Get the last name of the user.
+     *
+     * @return string
+     */
+    public function getLastname()
+    {
+        return $this->lastname;
+    }
+
+    /**
+     * Get the role of the user.
+     *
+     * @return string
+     */
+    public function getRole()
+    {
+        return $this->role;
     }
 
     /**

--- a/vendor/laravel/socialite/src/SocialiteManager.php
+++ b/vendor/laravel/socialite/src/SocialiteManager.php
@@ -12,6 +12,7 @@ use Laravel\Socialite\One\TwitterProvider;
 use Laravel\Socialite\Two\FacebookProvider;
 use Laravel\Socialite\Two\LinkedInProvider;
 use Laravel\Socialite\Two\BitbucketProvider;
+use Laravel\Socialite\Two\OpenIdConnectProvider;
 use League\OAuth1\Client\Server\Twitter as TwitterServer;
 
 class SocialiteManager extends Manager implements Contracts\Factory
@@ -98,6 +99,20 @@ class SocialiteManager extends Manager implements Contracts\Factory
     }
 
     /**
+     * Create an instance of the specified driver.
+     *
+     * @return \Laravel\Socialite\Two\AbstractProvider
+     */
+    protected function createOpenIdConnectDriver()
+    {
+        $config = $this->app['config']['services.openid_connect'];
+
+        return $this->buildProvider(
+            OpenIdConnectProvider::class, $config
+        );
+    }
+
+    /**
      * Build an OAuth 2 provider instance.
      *
      * @param  string  $provider
@@ -108,7 +123,7 @@ class SocialiteManager extends Manager implements Contracts\Factory
     {
         return new $provider(
             $this->app['request'], $config['client_id'],
-            $config['client_secret'], $this->formatRedirectUrl($config),
+            $config['client_secret'], $config['base_url'], $this->formatRedirectUrl($config),
             Arr::get($config, 'guzzle', [])
         );
     }

--- a/vendor/laravel/socialite/src/Two/AbstractProvider.php
+++ b/vendor/laravel/socialite/src/Two/AbstractProvider.php
@@ -41,6 +41,13 @@ abstract class AbstractProvider implements ProviderContract
     protected $clientSecret;
 
     /**
+     * The provider base URL.
+     *
+     * @var string
+     */
+    protected $base_url;
+
+    /**
      * The redirect URL.
      *
      * @var string
@@ -95,17 +102,19 @@ abstract class AbstractProvider implements ProviderContract
      * @param  \Illuminate\Http\Request  $request
      * @param  string  $clientId
      * @param  string  $clientSecret
+     * @param  string  $base_url
      * @param  string  $redirectUrl
      * @param  array  $guzzle
      * @return void
      */
-    public function __construct(Request $request, $clientId, $clientSecret, $redirectUrl, $guzzle = [])
+    public function __construct(Request $request, $clientId, $clientSecret, $base_url, $redirectUrl, $guzzle = [])
     {
         $this->guzzle = $guzzle;
         $this->request = $request;
         $this->clientId = $clientId;
         $this->redirectUrl = $redirectUrl;
         $this->clientSecret = $clientSecret;
+        $this->base_url = $base_url;
     }
 
     /**
@@ -277,7 +286,7 @@ abstract class AbstractProvider implements ProviderContract
     {
         return [
             'client_id' => $this->clientId, 'client_secret' => $this->clientSecret,
-            'code' => $code, 'redirect_uri' => $this->redirectUrl,
+            'base_url' => $this->base_url, 'code' => $code, 'redirect_uri' => $this->redirectUrl,
         ];
     }
 

--- a/vendor/laravel/socialite/src/Two/OpenIdConnectProvider.php
+++ b/vendor/laravel/socialite/src/Two/OpenIdConnectProvider.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Laravel\Socialite\Two;
+
+use Exception;
+use GuzzleHttp\ClientInterface;
+
+class OpenIdConnectProvider extends AbstractProvider implements ProviderInterface
+{
+    /**
+     * The scopes being requested.
+     *
+     * @var array
+     */
+    protected $scopes = ['email'];
+
+    /**
+     * The separating character for the requested scopes.
+     *
+     * @var string
+     */
+    protected $scopeSeparator = ' ';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getBaseUrl()
+    {
+		return $this->base_url;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getAuthUrl($state)
+    {
+        return $this->buildAuthUrlFromBase($this->getBaseUrl().'/protocol/openid-connect/auth', $state);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getLogoutUrl()
+    {
+        return $this->getBaseUrl().'/protocol/openid-connect/logout/?redirect_uri='.$this->redirectUrl;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getTokenUrl()
+    {
+        return $this->getBaseUrl().'/protocol/openid-connect/token';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getUserByToken($token)
+    {
+        $response = $this->getHttpClient()->get($this->getBaseUrl().'/protocol/openid-connect/userinfo', [
+            'headers' => [
+                'Authorization' => 'Bearer '.$token,
+            ],
+        ]);
+
+        return json_decode($response->getBody(), true);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function mapUserToObject(array $user)
+    {
+        return (new User())->setRaw($user)->map([
+            'lastname'  => array_get($user, 'family_name'),
+            'nickname'  => array_get($user, 'preferred_username'),
+            'name'      => array_get($user, 'given_name'),
+            'email'     => array_get($user, 'email'),
+            'role'     => array_get($user, 'roles')[0],
+        ]);
+    }
+
+    /**
+     * Get the access token for the given code.
+     *
+     * @param  string  $code
+     * @return string
+     */
+    public function getAccessToken($code)
+    {
+        $postKey = (version_compare(ClientInterface::VERSION, '6') === 1) ? 'form_params' : 'body';
+
+        $response = $this->getHttpClient()->post($this->getTokenUrl(), [
+            'auth' => [$this->clientId, $this->clientSecret],
+            'headers' => ['Accept' => 'application/json'],
+            $postKey => $this->getTokenFields($code),
+        ]);
+
+        return json_decode($response->getBody(), true)['access_token'];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getTokenFields($code)
+    {
+        return array_merge(parent::getTokenFields($code), [
+            'grant_type' => 'authorization_code',
+        ]);
+    }
+}

--- a/vendor/league/oauth1-client/composer.json
+++ b/vendor/league/oauth1-client/composer.json
@@ -21,6 +21,7 @@
         "sso",
         "single sign on",
         "bitbucket",
+        "openid_connect",
         "trello",
         "tumblr",
         "twitter"


### PR DESCRIPTION
This PR allows addition of a generic OpenID Connect provider to the Social Media channels for creating new users.
A provider can be configured by entering `Client ID`, `Client Secret` and `Base URL` in the `OpenID Connect` interface in the Social Login section of Settings panel.
Once the provider has been configured and made active, every new user who tries to log in the Faveo home page will be redirected to the `Base URL` previously configured, there he will proceed with login, and once it's done his personal data will be added in the Faveo database.
Changes has been tested with [Keycloak](https://www.keycloak.org/) identity provider, with some test users in it and configuring it as OpenID Connect provider for Faveo, personal data of the test user are correctly copied in Faveo database.