### PR TITLE
getting internal server error if there is no user with mobile number

### DIFF
--- a/app/Http/Controllers/Agent/helpdesk/TicketController.php
+++ b/app/Http/Controllers/Agent/helpdesk/TicketController.php
@@ -609,8 +609,8 @@ class TicketController extends Controller
      */
     public function checkMobile($mobile)
     {
-        $check = User::where('mobile', '=', $mobile)->first();
-        if (count($check) > 0) {
+        $check = User::where('mobile', '=', $mobile);
+        if ($check && $check->count() > 0) {
             return true;
         }
 


### PR DESCRIPTION
Error: `count(): Argument #1 ($value) must be of type Countable|array, null given`

It is giving an error as $check will be an instance of App\User which is not a Countable|array.

![image](https://github.com/ladybirdweb/faveo-helpdesk/assets/16561538/812d3da3-868b-4e40-8026-891163ee596d)
