### PR TITLE
Auth controller fix.

### DIFF
--- a/app/Http/Controllers/Auth/AuthController.php
+++ b/app/Http/Controllers/Auth/AuthController.php
@@ -187,7 +187,7 @@ class AuthController extends Controller
             $user->save();
             $message12 = '';
             $settings = CommonSettings::select('status')->where('option_name', '=', 'send_otp')->first();
-            $sms = Plugin::select('status')->where('name', '=', 'SMS')->first();
+            $sms = Plugin::select('status')->where('name', '=', 'SMS')->first() ?? [];
             // Event for login
             event(new \App\Events\LoginEvent($request));
             if ($request->input('email') !== '') {


### PR DESCRIPTION
Query returns null fro $sms variable but it is used for count function. So it causes 500 error whenever sms variable null.