### PR TITLE
Mail controller controller fix.

### DIFF
--- a/app/Http/Controllers/Common/PhpMailController.php
+++ b/app/Http/Controllers/Common/PhpMailController.php
@@ -185,7 +185,8 @@ class PhpMailController extends Controller
                 $config = ['host' => $mail->sending_host,
                     'port'        => $mail->sending_port,
                     'security'    => $mail->sending_encryption,
-                    'username'    => $mail->email_address,
+                    'username'    => $mail->user_name ?? $mail->email_address,
+                    'from_mail'   => $mail->email_address,
                     'password'    => $mail->password,
                 ];
                 if (!$this->commonMailer->setSmtpDriver($config)) {


### PR DESCRIPTION
Whenever we want to use mail providers like sendgrid we need to use different username then mail address. So this functionality is needed and added.