### PR TITLE
Added auth to ticket attachments controller

### DIFF
--- a/app/Http/Controllers/Agent/helpdesk/MailController.php
+++ b/app/Http/Controllers/Agent/helpdesk/MailController.php
@@ -356,6 +356,14 @@ class MailController extends Controller
     {
         $id = $request->input('image_id');
         $attachment = \App\Model\helpdesk\Ticket\Ticket_attachments::where('id', '=', $id)->first();
+        $current_user = \Auth::user();
+        if(!in_array($current_user->role, ['admin', 'agent'])) {
+            $thereat = \App\Model\helpdesk\Ticket\Ticket_Thread::where('id', '=', $attachment->thread_id)->first();
+            $ticket = \App\Model\helpdesk\Ticket\Ticket::where('id', '=', $thereat->ticket_id)->first();
+            if ($ticket->user_id != $current_user->id) {
+                return redirect('unauthorized')->with('error', 'You are not authorized to view this file');
+            }
+        }
         if (mime($attachment->type) == true) {
             echo "<img src=data:$attachment->type;base64,".$attachment->file.'>';
         } else {

--- a/app/Http/Controllers/Agent/helpdesk/MailController.php
+++ b/app/Http/Controllers/Agent/helpdesk/MailController.php
@@ -357,7 +357,7 @@ class MailController extends Controller
         $id = $request->input('image_id');
         $attachment = \App\Model\helpdesk\Ticket\Ticket_attachments::where('id', '=', $id)->first();
         $current_user = \Auth::user();
-        if(!in_array($current_user->role, ['admin', 'agent'])) {
+        if (!in_array($current_user->role, ['admin', 'agent'])) {
             $thereat = \App\Model\helpdesk\Ticket\Ticket_Thread::where('id', '=', $attachment->thread_id)->first();
             $ticket = \App\Model\helpdesk\Ticket\Ticket::where('id', '=', $thereat->ticket_id)->first();
             if ($ticket->user_id != $current_user->id) {


### PR DESCRIPTION
Any user can access to all attachments via increasing the id number since the attachments ids are auto increment numbers. So it is necessary to add authorization.